### PR TITLE
[ext/create-link] Copying Links in a Custom User-Defined Format

### DIFF
--- a/extensions/create-link/package.json
+++ b/extensions/create-link/package.json
@@ -31,6 +31,24 @@
       "subtitle": "Create Link",
       "description": "This command captures the current URL from your browser, formats it as a Markdown link, and copies it to your clipboard. This is useful for integrating links into Markdown documents or notes.",
       "mode": "no-view"
+    },
+    {
+      "name": "copy-custom",
+      "title": "Copy Link as Custom",
+      "subtitle": "Create Link",
+      "description": "This command captures the current URL from your browser, formats it as a custom link, and copies it to your clipboard. You can customize the link format to suit your needs.",
+      "mode": "no-view",
+      "preferences": [
+        {
+          "name": "customFormat",
+          "key": "customFormat",
+          "required": true,
+          "type": "textfield",
+          "title": "Custom Link Format",
+          "description": "Enter the desired format for the custom link. Available placeholders: {url} for the URL, {title} for the page title, {id} for the tab ID, and {favicon} for the favicon URL.",
+          "default": "{url}"
+        }
+      ]
     }
   ],
   "dependencies": {

--- a/extensions/create-link/src/copy-custom.ts
+++ b/extensions/create-link/src/copy-custom.ts
@@ -3,7 +3,7 @@ import { isExtensionInstalled, getActiveTab } from "./utils/browser";
 
 interface CopyCustomPreferences {
   customFormat: string;
-};
+}
 
 function sanitizeUrl(url: string): string {
   try {
@@ -20,7 +20,11 @@ function formatCustomLink(format: string, tab: BrowserExtension.Tab): string {
   const safeTitle = title || "";
   const safeFavicon = favicon || "";
 
-  return format.replace(/\{url\}/g, safeUrl).replace(/\{title\}/g, safeTitle).replace(/\{id\}/g, String(id)).replace(/\{favicon\}/g, safeFavicon);
+  return format
+    .replace(/\{url\}/g, safeUrl)
+    .replace(/\{title\}/g, safeTitle)
+    .replace(/\{id\}/g, String(id))
+    .replace(/\{favicon\}/g, safeFavicon);
 }
 
 export default async function copyCustom() {

--- a/extensions/create-link/src/copy-custom.ts
+++ b/extensions/create-link/src/copy-custom.ts
@@ -1,0 +1,45 @@
+import { showHUD, Clipboard, getPreferenceValues, BrowserExtension } from "@raycast/api";
+import { isExtensionInstalled, getActiveTab } from "./utils/browser";
+
+interface CopyCustomPreferences {
+  customFormat: string;
+};
+
+function sanitizeUrl(url: string): string {
+  try {
+    new URL(url);
+    return url;
+  } catch {
+    return "about:blank";
+  }
+}
+
+function formatCustomLink(format: string, tab: BrowserExtension.Tab): string {
+  const { url, title, id, favicon } = tab;
+  const safeUrl = sanitizeUrl(url);
+  const safeTitle = title || "";
+  const safeFavicon = favicon || "";
+
+  return format.replace(/\{url\}/g, safeUrl).replace(/\{title\}/g, safeTitle).replace(/\{id\}/g, String(id)).replace(/\{favicon\}/g, safeFavicon);
+}
+
+export default async function copyCustom() {
+  if (!isExtensionInstalled()) {
+    await showHUD("Extension not installed");
+    return;
+  }
+
+  const activeTab = await getActiveTab();
+  if (activeTab === undefined) {
+    await showHUD("No active tab found");
+    return;
+  }
+
+  const preferences = getPreferenceValues<CopyCustomPreferences>();
+  const { customFormat } = preferences;
+
+  const customLink = formatCustomLink(customFormat, activeTab);
+
+  await Clipboard.copy(customLink);
+  await showHUD(`Copied HTML Link for "${activeTab.title || ""}" to clipboard`);
+}

--- a/extensions/create-link/src/copy-custom.ts
+++ b/extensions/create-link/src/copy-custom.ts
@@ -14,13 +14,13 @@ function sanitizeUrl(url: string): string {
   }
 }
 
-function formatCustomLink(format: string, tab: BrowserExtension.Tab): string {
+function applyCustomTemplate(template: string, tab: BrowserExtension.Tab): string {
   const { url, title, id, favicon } = tab;
   const safeUrl = sanitizeUrl(url);
   const safeTitle = title || "";
   const safeFavicon = favicon || "";
 
-  return format
+  return template
     .replace(/\{url\}/g, safeUrl)
     .replace(/\{title\}/g, safeTitle)
     .replace(/\{id\}/g, String(id))
@@ -42,7 +42,7 @@ export default async function copyCustom() {
   const preferences = getPreferenceValues<CopyCustomPreferences>();
   const { customFormat } = preferences;
 
-  const customLink = formatCustomLink(customFormat, activeTab);
+  const customLink = applyCustomTemplate(customFormat, activeTab);
 
   await Clipboard.copy(customLink);
   await showHUD(`Copied HTML Link for "${activeTab.title || ""}" to clipboard`);

--- a/extensions/create-link/src/copy-custom.ts
+++ b/extensions/create-link/src/copy-custom.ts
@@ -1,7 +1,7 @@
 import { showHUD, Clipboard, getPreferenceValues, BrowserExtension } from "@raycast/api";
 import { isExtensionInstalled, getActiveTab } from "./utils/browser";
 
-interface CopyCustomPreferences {
+interface CopyCustomFormatPreferences {
   customFormat: string;
 }
 
@@ -39,7 +39,7 @@ export default async function copyCustom() {
     return;
   }
 
-  const preferences = getPreferenceValues<CopyCustomPreferences>();
+  const preferences = getPreferenceValues<CopyCustomFormatPreferences>();
   const { customFormat } = preferences;
 
   const customLink = applyCustomTemplate(customFormat, activeTab);


### PR DESCRIPTION
## Description

This pull request introduces a new "Copy Link as Custom" command that retrieves the active browser tab’s URL and title, then copies the link to your clipboard using a user-defined format. You can define any structure you want, inserting placeholders such as {url}, {title}, {id}, or {favicon} to customize how the link is copied. This feature allows users to generate links precisely in the style or layout that suits their workflow.

## Screencast

![CleanShot 2025-03-22 at 01 46 40](https://github.com/user-attachments/assets/1db0ce40-2fb6-402c-9a18-3535d5856426)


https://github.com/user-attachments/assets/fec8718d-5bd8-4193-bcfe-01f8eb1550be

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
